### PR TITLE
Update Format-Certificate.ps1

### DIFF
--- a/Format-Certificate.ps1
+++ b/Format-Certificate.ps1
@@ -22,6 +22,8 @@
  .Example   
    Format-Certificate -CertPath C:\temp\CER -KeyPath C:\temp\KEY
 #>
+
+
 function Format-Certificate {
     [CmdletBinding()]
     param(


### PR DESCRIPTION
Added two spaces between comment block and first function call per https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_comment_based_help?view=powershell-7